### PR TITLE
Display per monitor workspaces

### DIFF
--- a/src/components/WorkspaceControls.tsx
+++ b/src/components/WorkspaceControls.tsx
@@ -12,7 +12,7 @@ interface WorkspaceControlsProps {
 
 export function WorkspaceControls({ glazewm }: WorkspaceControlsProps) {
   if (!glazewm) return null;
-  const workspaces = glazewm.allWorkspaces;
+  const workspaces = glazewm.currentWorkspaces;
 
   const [ref, { width }] = useMeasure();
   const springConfig = {
@@ -54,7 +54,7 @@ export function WorkspaceControls({ glazewm }: WorkspaceControlsProps) {
         ref={ref}
         onWheel={handleWheel}
       >
-        {glazewm.allWorkspaces?.map((workspace: Workspace, idx) => {
+        {workspaces.map((workspace: Workspace, idx) => {
           const isFocused = workspace.hasFocus;
           return (
             <button


### PR DESCRIPTION
Support displaying per monitor workspace:

- Previously, if there were multiple monitors, they would all share one workspace, which isn't really good behavior by default 