### PR TITLE
Implement configs for zebar

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,6 +37,8 @@ jobs:
           mkdir -p overline-zebar/dist
           cp -r dist/* overline-zebar/dist/
           cp overline.zebar.json overline-zebar/overline.zebar.json
+          mkdir -p overline-zebar/dist/public
+          cp public/release-config.json overline-zebar/dist/public/config.json
 
       # Zip the release folder
       - name: Zip release folder

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ A fully-featured custom widget for [zebar](https://github.com/glzr-io/zebar).
 
 This is the easiest and fastest way to get overline-zebar up and running. Choose this option if you want to use the widget with its default configuration.
 
-*This uses Flow Launcher as the default launcher application. If you use a different launcher, you will need to build the widget from source.*
+_This uses Flow Launcher as the default launcher application. See the [Configuration](#configuration) section below to learn how to change the launcher application._
 
 1. Go to the [Releases page](https://github.com/mushfikurr/overline-zebar/releases) on GitHub
 2. Download the latest `overline-zebar.zip` file
@@ -42,6 +42,41 @@ This is the easiest and fastest way to get overline-zebar up and running. Choose
 4. Enable the widget by expanding the "Widget configs" option, selecting "overline-zebar > default", and clicking "Enable". You can also enable the widget to startup the same way.
 5. Position the widget dimensions and position by right clicking the Zebar system tray icon and selecting "Open Settings".
 6. Save your configuration by clicking "Save" in the Zebar settings window
+
+## Configuration
+
+You can customize various aspects of overline-zebar by editing the `config.json` file. This file allows you to change settings without modifying the source code.
+
+### Configuration File Location
+
+- **For pre-built version users**: Navigate to:
+
+  ```
+  C:\Users\<username>\.glzr\zebar\overline-zebar\dist\public\
+  ```
+
+- **For developers building from source**: Navigate to:
+  ```
+  public/
+  ```
+
+### Creating or Editing the Configuration File
+
+1. The pre-built version includes a `config.json` file, while the source code includes a `release-config.json` file which serves as a template for the built version. If you're building from source, modify `config.json` in the `public/` directory.
+
+2. Add your desired configuration options to the file. Here's an example with all available options:
+
+   ```json
+   {
+     "FLOW_LAUNCHER_PATH": "C:\\Program Files\\YourLauncher\\YourLauncher.exe",
+     "USE_AUTOTILING": true,
+     "AUTOTILING_WEBSOCKET_URI": "ws://localhost:6123"
+   }
+   ```
+
+   Make sure to use double backslashes (`\\`) in any file paths.
+
+3. Save the file and restart Zebar for the changes to take effect
 
 ### Option 2: Build from Source
 
@@ -74,20 +109,7 @@ Detailed steps:
 
    This will install React, Vite, TailwindCSS, and all other dependencies needed for development.
 
-3. Create a `.env` file in the root directory to customize behavior (optional):
-
-   ```sh
-   # Path to your Flow Launcher executable (if you use Flow Launcher)
-   VITE_FLOW_LAUNCHER_PATH=C:\Program Files\FlowLauncher\Flow.Launcher.exe
-
-   # Enable or disable auto-tiling functionality
-   VITE_USE_AUTOTILING=false
-
-   # WebSocket URI for auto-tiling functionality
-   VITE_AUTOTILING_WEBSOCKET_URI=ws://localhost:6123
-   ```
-
-   You can customize these values based on your specific setup and preferences.
+3. See the [Configuration](#configuration) section below for details on how to customize the widget by editing the `public/config.json` file.
 
 4. Build the project for production:
    ```sh
@@ -95,29 +117,29 @@ Detailed steps:
    ```
    This creates a `dist` folder containing the compiled widget ready for use.
 
-### Environment Variables (For Custom Builds Only)
+### Configuration Options
 
-These variables only apply if you're building the project yourself. They allow you to customize key aspects of the widget's functionality without modifying the source code directly.
+These configuration options allow you to customize key aspects of the widget's functionality without modifying the source code directly. You can edit these in the `config.json` file.
 
-- **`VITE_FLOW_LAUNCHER_PATH`**: Path to an `.exe` file executed when clicking the search icon
+- **`FLOW_LAUNCHER_PATH`**: Path to an `.exe` file executed when clicking the search icon
 
-  - Default: `C:\Program Files\FlowLauncher\Flow.Launcher.exe`
+  - Default: `C:\Users\username\AppData\Local\FlowLauncher\Flow.Launcher.exe`
   - Example custom value: `C:\Program Files\Launchers\MyCustomLauncher.exe`
   - Set this if you use a different launcher application or if Flow Launcher is installed in a non-standard location
 
-- **`VITE_USE_AUTOTILING`**: Controls the auto-tiling functionality
+- **`USE_AUTOTILING`**: Controls the auto-tiling functionality
 
   - Default: `false`
   - Set to `true` to enable automatic tiling direction switching
   - When enabled, new windows will automatically switch tiling directions based on the size of the focused window
   - This creates a more efficient use of screen space for different window sizes
 
-- **`VITE_AUTOTILING_WEBSOCKET_URI`**: WebSocket URI for auto-tiling functionality
+- **`AUTOTILING_WEBSOCKET_URI`**: WebSocket URI for auto-tiling functionality
   - Default: `ws://localhost:6123`
   - Change this if you're running the WebSocket server on a different port or machine
-  - Only relevant if `VITE_USE_AUTOTILING` is set to `true`
+  - Only relevant if `USE_AUTOTILING` is set to `true`
 
-**Note:** All environment variables have sensible defaults, so the `.env` file is only needed if you want to override these defaults. If you don't create an `.env` file, the widget will use the default values.
+**Note:** All configuration options have sensible defaults. You only need to modify the `config.json` file if you want to override these defaults.
 
 ---
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,17 +1,17 @@
 import { useEffect, useState } from "react";
 import * as zebar from "zebar";
 import { Center } from "./components/Center";
-import { TilingControl } from "./components/TilingControl";
-import { WindowTitle } from "./components/windowTitle/WindowTitle";
-import { WorkspaceControls } from "./components/WorkspaceControls";
 import { Chip } from "./components/common/Chip";
 import CurrentTrack from "./components/media";
 import Stat from "./components/stat";
 import { weatherThresholds } from "./components/stat/defaults/thresholds";
+import { TilingControl } from "./components/TilingControl";
 import VolumeControl from "./components/volume";
+import { WindowTitle } from "./components/windowTitle/WindowTitle";
+import { WorkspaceControls } from "./components/WorkspaceControls";
+import "./styles/fonts.css";
 import { useAutoTiling } from "./utils/useAutoTiling";
 import { getWeatherIcon } from "./utils/weatherIcons";
-import "./styles/fonts.css";
 
 const providers = zebar.createProviderGroup({
   media: { type: "media" },
@@ -31,10 +31,8 @@ function App() {
     providers.onOutput(() => setOutput(providers.outputMap));
   }, []);
 
-  console.log(import.meta.env.VITE_USE_AUTOTILING);
-  if (import.meta.env.VITE_USE_AUTOTILING === "true") {
-    useAutoTiling();
-  }
+  useAutoTiling();
+
   const statIconClassnames = "h-3 w-3 text-icon";
 
   return (

--- a/src/components/TilingControl.tsx
+++ b/src/components/TilingControl.tsx
@@ -3,32 +3,15 @@ import { cn } from "../utils/cn";
 import { Button } from "./common/Button";
 import { GlazeWmOutput } from "zebar";
 import { motion, AnimatePresence } from "framer-motion";
+import { useConfig } from "../context/ConfigContext";
 
 interface TilingControlProps {
   glazewm: GlazeWmOutput | null;
 }
 
-// Try to get the Flow Launcher path from environment variables, or use a default path
-const getFlowLauncherPath = () => {
-  // First check if the environment variable is available
-  if (import.meta.env.VITE_FLOW_LAUNCHER_PATH) {
-    return import.meta.env.VITE_FLOW_LAUNCHER_PATH;
-  }
-
-  // Default paths based on OS
-  // For Windows (most common Flow Launcher location)
-  const defaultWindowsPath =
-    "C:\\Program Files\\FlowLauncher\\Flow.Launcher.exe";
-  const appDataPath =
-    "C:\\Users\\%USERNAME%\\AppData\\Local\\FlowLauncher\\Flow.Launcher.exe";
-
-  // Return the default path (users can customize this in their own builds)
-  return defaultWindowsPath;
-};
-
-const FLOW_LAUNCHER_PATH = getFlowLauncherPath();
-
 export function TilingControl({ glazewm }: TilingControlProps) {
+  const { flowLauncherPath, isLoading } = useConfig();
+  
   if (!glazewm) return null;
 
   return (
@@ -50,12 +33,13 @@ export function TilingControl({ glazewm }: TilingControlProps) {
 
       <Button
         onClick={() => {
-          if (FLOW_LAUNCHER_PATH) {
-            glazewm.runCommand(`shell-exec ${FLOW_LAUNCHER_PATH}`);
+          if (flowLauncherPath && !isLoading) {
+            console.log("Flow Launcher path:", flowLauncherPath);
+            glazewm.runCommand(`shell-exec ${flowLauncherPath}`);
+          } else if (isLoading) {
+            console.warn("Configuration is still loading...");
           } else {
-            console.warn(
-              "Flow Launcher path not configured. Set VITE_FLOW_LAUNCHER_PATH in .env file."
-            );
+            console.warn("Flow Launcher path not configured in config.json");
           }
         }}
       >

--- a/src/context/ConfigContext.tsx
+++ b/src/context/ConfigContext.tsx
@@ -1,0 +1,62 @@
+import React, { createContext, useContext, useState, useEffect, ReactNode } from 'react';
+import { 
+  getFlowLauncherPath, 
+  getUseAutoTiling, 
+  getAutoTilingWebSocketUri 
+} from '../utils/getFromEnv';
+
+interface ConfigContextType {
+  flowLauncherPath: string;
+  useAutoTiling: boolean;
+  autoTilingWebSocketUri: string;
+  isLoading: boolean;
+}
+
+const defaultConfig: ConfigContextType = {
+  flowLauncherPath: 'C:\\Program Files\\FlowLauncher\\Flow.Launcher.exe',
+  useAutoTiling: false,
+  autoTilingWebSocketUri: 'ws://localhost:6123',
+  isLoading: true
+};
+
+const ConfigContext = createContext<ConfigContextType>(defaultConfig);
+
+export const useConfig = () => useContext(ConfigContext);
+
+interface ConfigProviderProps {
+  children: ReactNode;
+}
+
+export const ConfigProvider: React.FC<ConfigProviderProps> = ({ children }) => {
+  const [config, setConfig] = useState<ConfigContextType>(defaultConfig);
+
+  useEffect(() => {
+    const loadConfig = async () => {
+      try {
+        const [flowLauncherPath, useAutoTiling, autoTilingWebSocketUri] = await Promise.all([
+          getFlowLauncherPath(),
+          getUseAutoTiling(),
+          getAutoTilingWebSocketUri()
+        ]);
+
+        setConfig({
+          flowLauncherPath,
+          useAutoTiling,
+          autoTilingWebSocketUri,
+          isLoading: false
+        });
+      } catch (error) {
+        console.error('Failed to load configuration:', error);
+        setConfig(prev => ({ ...prev, isLoading: false }));
+      }
+    };
+
+    loadConfig();
+  }, []);
+
+  return (
+    <ConfigContext.Provider value={config}>
+      {children}
+    </ConfigContext.Provider>
+  );
+};

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,13 +3,22 @@ import { createRoot } from "react-dom/client";
 import "./index.css";
 import App from "./App";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { ConfigProvider } from "./context/ConfigContext";
 
 const queryClient = new QueryClient();
 
-createRoot(document.getElementById("root")).render(
+const rootElement = document.getElementById("root");
+
+if (!rootElement) {
+  throw new Error("Failed to find the root element");
+}
+
+createRoot(rootElement).render(
   <StrictMode>
     <QueryClientProvider client={queryClient}>
-      <App />
+      <ConfigProvider>
+        <App />
+      </ConfigProvider>
     </QueryClientProvider>
   </StrictMode>
 );

--- a/src/utils/useAutoTiling.tsx
+++ b/src/utils/useAutoTiling.tsx
@@ -1,17 +1,16 @@
 import { useEffect } from "react";
 import { useQueryClient } from "@tanstack/react-query";
-import { getUseAutoTiling, getAutoTilingWebSocketUri } from "./getFromEnv";
+import { useConfig } from "../context/ConfigContext";
 
 export const useAutoTiling = () => {
   const queryClient = useQueryClient();
-  const uri = getAutoTilingWebSocketUri();
-  const isAutoTilingEnabled = getUseAutoTiling();
+  const { autoTilingWebSocketUri, useAutoTiling: isAutoTilingEnabled } = useConfig();
 
   useEffect(() => {
     // Only connect to WebSocket if auto-tiling is enabled
     if (!isAutoTilingEnabled) return;
 
-    const websocket = new WebSocket(uri);
+    const websocket = new WebSocket(autoTilingWebSocketUri);
 
     websocket.onopen = () => {
       websocket.send("sub -e window_managed");
@@ -44,7 +43,7 @@ export const useAutoTiling = () => {
     return () => {
       websocket.close();
     };
-  }, [queryClient, uri, isAutoTilingEnabled]);
+  }, [queryClient, autoTilingWebSocketUri, isAutoTilingEnabled]);
 
   return {
     tilingSize: queryClient.getQueryData(["tilingSize"]),


### PR DESCRIPTION
Config that can control features on the Zebar itself.

*This config is separate from the actual `.zebar.json` config.*

Allows us to configure things like paths to launcher applications, customising shell-exec commands, etc.

In this PR, we have a basic config.json of:

```
{
  "FLOW_LAUNCHER_PATH": "C:\\Program Files\\FlowLauncher\\Flow.Launcher.exe",
  "USE_AUTOTILING": false,
  "AUTOTILING_WEBSOCKET_URI": "ws://localhost:6123"
}
```

There are two configs in the source (`/public`):
- config.json: The users independant .json, that is carried over into their `public/` folder on build
- release-config.json: The config.json that is included in CI (the release .zip file, under /dist)

In the future, support different configuration options, such as:
- Colours
- Window title exclusions
- Weather colour thresholds & measurements
- Providers