### PR TITLE
Feature: CPU and RAM inline toggle, threshold settings for CPU and RAM and Battery

### DIFF
--- a/packages/config/src/ConfigReducer.tsx
+++ b/packages/config/src/ConfigReducer.tsx
@@ -74,9 +74,9 @@ export function configReducer(state: State, action: Action): State {
       return newState;
     }
     case 'UPDATE_WIDGET_SETTINGS': {
-      const newWidgets = { ...state.widgets };
+      const newWidgets = { ...state.widgets } as Record<string, unknown>;
       newWidgets[action.widget] = {
-        ...(newWidgets[action.widget] || {}),
+        ...((newWidgets[action.widget] as Record<string, unknown>) || {}),
         ...action.settings,
       };
       const newState = { ...state, widgets: newWidgets };
@@ -84,9 +84,9 @@ export function configReducer(state: State, action: Action): State {
       return newState;
     }
     case 'SET_WIDGET_SETTING': {
-      const newWidgets = { ...state.widgets };
+      const newWidgets = { ...state.widgets } as Record<string, unknown>;
       newWidgets[action.widget] = {
-        ...(newWidgets[action.widget] || {}),
+        ...((newWidgets[action.widget] as Record<string, unknown>) || {}),
         [action.key]: action.value,
       };
       const newState = { ...state, widgets: newWidgets };
@@ -94,9 +94,9 @@ export function configReducer(state: State, action: Action): State {
       return newState;
     }
     case 'SET_WIDGET_VISIBILITY': {
-      const newWidgets = { ...state.widgets };
+      const newWidgets = { ...state.widgets } as Record<string, unknown>;
       newWidgets[action.widget] = {
-        ...(newWidgets[action.widget] || {}),
+        ...((newWidgets[action.widget] as Record<string, unknown>) || {}),
         isVisible: action.visible,
       };
       return { ...state, widgets: newWidgets };

--- a/packages/config/src/ConfigService.tsx
+++ b/packages/config/src/ConfigService.tsx
@@ -74,10 +74,11 @@ function updateWidgetSetting(
   value: unknown
 ) {
   const config = loadConfig();
-  if (!config.widgets[widgetName]) {
-    config.widgets[widgetName] = {};
+  const widgets = config.widgets as Record<string, unknown>;
+  if (!widgets[widgetName]) {
+    widgets[widgetName] = {};
   }
-  config.widgets[widgetName][key] = value;
+  (widgets[widgetName] as Record<string, unknown>)[key] = value;
   saveConfig(config);
 }
 
@@ -88,7 +89,8 @@ function getAppSetting<K extends keyof RootConfig['app']>(
 }
 
 function getWidgetSetting(widgetName: string, key: string): unknown {
-  return loadConfig().widgets[widgetName]?.[key];
+  const widgets = loadConfig().widgets as Record<string, unknown>;
+  return (widgets[widgetName] as Record<string, unknown>)?.[key];
 }
 
 export const configService = {

--- a/packages/config/src/defaults/default-config.ts
+++ b/packages/config/src/defaults/default-config.ts
@@ -25,6 +25,11 @@ export const defaultConfig: RootConfig = {
         { id: 'stat-2', min: 70, max: 85, labelColor: '--warning' },
         { id: 'stat-3', min: 85, max: 100, labelColor: '--danger' },
       ],
+      batteryThresholds: [
+        { id: 'battery-1', min: 0, max: 20, labelColor: '--danger' },
+        { id: 'battery-2', min: 20, max: 60, labelColor: '--warning' },
+        { id: 'battery-3', min: 60, max: 100, labelColor: '--text' },
+      ],
       useInlineStats: false,
       pinnedSystrayIcons: [],
       weatherUnit: 'celsius',

--- a/packages/config/src/defaults/default-config.ts
+++ b/packages/config/src/defaults/default-config.ts
@@ -20,6 +20,12 @@ export const defaultConfig: RootConfig = {
         { id: 'weather-3', min: 16, max: 25, labelColor: '--warning' },
         { id: 'weather-4', min: 26, max: 35, labelColor: '--danger' },
       ],
+      systemStatThresholds: [
+        { id: 'stat-1', min: 0, max: 70, labelColor: '--text' },
+        { id: 'stat-2', min: 70, max: 85, labelColor: '--warning' },
+        { id: 'stat-3', min: 85, max: 100, labelColor: '--danger' },
+      ],
+      useInlineStats: false,
       pinnedSystrayIcons: [],
       weatherUnit: 'celsius',
       dynamicWorkspaceIndicator: false,

--- a/packages/config/src/hooks/useConfig.ts
+++ b/packages/config/src/hooks/useConfig.ts
@@ -7,20 +7,37 @@ export function useAppSetting<K extends keyof RootConfig['app']>(key: K) {
   return [
     state.app[key],
     (value: RootConfig['app'][K]) =>
-      dispatch({ type: 'SET_APP_SETTING', key, value }),
+      dispatch({
+        type: 'SET_APP_SETTING',
+        key: key as
+          | 'useAutoTiling'
+          | 'zebarWebsocketUri'
+          | 'currentThemeId'
+          | 'radius',
+        value: value as unknown as 'useAutoTiling' extends K
+          ? boolean
+          : 'zebarWebsocketUri' extends K
+            ? string
+            : 'currentThemeId' extends K
+              ? string
+              : 'radius' extends K
+                ? string
+                : never,
+      }),
   ] as const;
 }
 
 export function useWidgetSetting<
   T extends keyof AllWidgetSettings,
-  K extends keyof AllWidgetSettings[T],
+  K extends string,
 >(widgetName: T, key: K) {
   const state = useConfigState();
   const dispatch = useConfigDispatch();
 
-  const value = state.widgets[widgetName]?.[key];
+  const widgets = state.widgets as Record<string, Record<string, unknown>>;
+  const value = widgets[widgetName]?.[key];
 
-  const setValue = (value: AllWidgetSettings[T][K]) => {
+  const setValue = (value: unknown) => {
     dispatch({ type: 'SET_WIDGET_SETTING', widget: widgetName, key, value });
   };
 

--- a/packages/config/src/hooks/useConfig.ts
+++ b/packages/config/src/hooks/useConfig.ts
@@ -1,4 +1,4 @@
-import { AllWidgetSettings, RootConfig } from '../types';
+import { RootConfig, WidgetSettingsMap } from '../types';
 import { useConfigDispatch, useConfigState } from './useConfigContext';
 
 export function useAppSetting<K extends keyof RootConfig['app']>(key: K) {
@@ -28,18 +28,28 @@ export function useAppSetting<K extends keyof RootConfig['app']>(key: K) {
 }
 
 export function useWidgetSetting<
-  T extends keyof AllWidgetSettings,
-  K extends string,
->(widgetName: T, key: K) {
+  W extends keyof WidgetSettingsMap,
+  K extends keyof WidgetSettingsMap[W],
+>(
+  widgetName: W,
+  key: K
+): [WidgetSettingsMap[W][K], (value: WidgetSettingsMap[W][K]) => void] {
   const state = useConfigState();
   const dispatch = useConfigDispatch();
 
-  const widgets = state.widgets as Record<string, Record<string, unknown>>;
-  const value = widgets[widgetName]?.[key];
+  const widgets = state.widgets as WidgetSettingsMap;
+  const value = (widgets[widgetName] as Record<string, unknown>)?.[
+    key as string
+  ] as WidgetSettingsMap[W][K];
 
-  const setValue = (value: unknown) => {
-    dispatch({ type: 'SET_WIDGET_SETTING', widget: widgetName, key, value });
+  const setValue = (value: WidgetSettingsMap[W][K]) => {
+    dispatch({
+      type: 'SET_WIDGET_SETTING',
+      widget: widgetName,
+      key: key as string,
+      value,
+    });
   };
 
-  return [value, setValue] as const;
+  return [value, setValue];
 }

--- a/packages/config/src/hooks/useThemePreview.ts
+++ b/packages/config/src/hooks/useThemePreview.ts
@@ -12,7 +12,9 @@ export function useThemePreview() {
   const applyPreviewStyles = useCallback((theme: Theme) => {
     // Apply locally for instant feedback
     Object.entries(theme.colors).forEach(([key, value]) => {
-      document.documentElement.style.setProperty(key, value);
+      if (value !== undefined) {
+        document.documentElement.style.setProperty(key, value);
+      }
     });
     // Broadcast to other widgets
     zebar.currentWidget().tauriWindow.emit('theme-preview-update', theme);
@@ -37,9 +39,13 @@ export function useThemePreview() {
     (updatedProperties: Partial<Theme['colors']>) => {
       setPreviewTheme((currentPreview) => {
         if (!currentPreview) return null;
+        const newColors = {
+          ...currentPreview.colors,
+          ...updatedProperties,
+        } as Record<string, string>;
         const newPreview = {
           ...currentPreview,
-          colors: { ...currentPreview.colors, ...updatedProperties },
+          colors: newColors,
         };
         applyPreviewStyles(newPreview);
         return newPreview;

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -12,8 +12,11 @@ export type {
   AllWidgetSettings,
   AppSettings,
   LabelColor,
+  MainWidgetSettings,
   ProviderSettings,
   RootConfig,
+  ScriptLauncherWidgetSettings,
   Theme,
   Threshold,
+  WidgetSettingsMap,
 } from './types';

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -15,5 +15,5 @@ export type {
   ProviderSettings,
   RootConfig,
   Theme,
-  WeatherThreshold,
+  Threshold,
 } from './types';

--- a/packages/config/src/ipc/callbacks/window-events.ts
+++ b/packages/config/src/ipc/callbacks/window-events.ts
@@ -1,0 +1,14 @@
+import { Event } from '@tauri-apps/api/event';
+import { Dispatch } from '../../ConfigReducer';
+
+export async function listenForAlwaysOnEvents(
+  widgetName: string,
+  event: Event<unknown>,
+  dispatch: Dispatch
+): Promise<void> {
+  // Stub implementation - alwaysOn functionality not yet implemented
+  console.warn(
+    'listenForAlwaysOnEvents not implemented for widget:',
+    widgetName
+  );
+}

--- a/packages/config/src/ipc/ipc-types.ts
+++ b/packages/config/src/ipc/ipc-types.ts
@@ -1,1 +1,6 @@
 export const WIDGET_IPC_CHANNEL = 'widget-manager';
+
+export interface WidgetIpcPayload {
+  action: string;
+  payload?: unknown;
+}

--- a/packages/config/src/types.ts
+++ b/packages/config/src/types.ts
@@ -14,6 +14,7 @@ import {
 export type Theme = z.infer<typeof ThemeSchema>;
 export type LabelColor = z.infer<typeof LabelColorSchema>;
 export type WeatherThreshold = z.infer<typeof WeatherThresholdSchema>;
+export type Threshold = WeatherThreshold;
 export type AppSettings = z.infer<typeof AppSettingsSchema>;
 export type MainWidgetSettings = z.infer<typeof MainWidgetSettingsSchema>;
 export type AllWidgetSettings = z.infer<typeof AllWidgetSettingsSchema>;

--- a/packages/config/src/types.ts
+++ b/packages/config/src/types.ts
@@ -7,6 +7,7 @@ import {
   MainWidgetSettingsSchema,
   ProviderSettingsSchema,
   RootConfigSchema,
+  ScriptLauncherWidgetSettingsSchema,
   ThemeSchema,
   WeatherThresholdSchema,
 } from './zod-types';
@@ -17,7 +18,16 @@ export type WeatherThreshold = z.infer<typeof WeatherThresholdSchema>;
 export type Threshold = WeatherThreshold;
 export type AppSettings = z.infer<typeof AppSettingsSchema>;
 export type MainWidgetSettings = z.infer<typeof MainWidgetSettingsSchema>;
+export type ScriptLauncherWidgetSettings = z.infer<
+  typeof ScriptLauncherWidgetSettingsSchema
+>;
 export type AllWidgetSettings = z.infer<typeof AllWidgetSettingsSchema>;
 export type RootConfig = z.infer<typeof RootConfigSchema>;
 export type ProviderSettings = z.infer<typeof ProviderSettingsSchema>;
 export type LauncherCommand = z.infer<typeof LauncherCommandSchema>;
+
+export type WidgetSettingsMap = {
+  main: MainWidgetSettings;
+  'script-launcher': ScriptLauncherWidgetSettings;
+  'config-widget': Record<string, unknown>;
+};

--- a/packages/config/src/types.ts
+++ b/packages/config/src/types.ts
@@ -9,13 +9,12 @@ import {
   RootConfigSchema,
   ScriptLauncherWidgetSettingsSchema,
   ThemeSchema,
-  WeatherThresholdSchema,
+  ThresholdSchema,
 } from './zod-types';
 
 export type Theme = z.infer<typeof ThemeSchema>;
 export type LabelColor = z.infer<typeof LabelColorSchema>;
-export type WeatherThreshold = z.infer<typeof WeatherThresholdSchema>;
-export type Threshold = WeatherThreshold;
+export type Threshold = z.infer<typeof ThresholdSchema>;
 export type AppSettings = z.infer<typeof AppSettingsSchema>;
 export type MainWidgetSettings = z.infer<typeof MainWidgetSettingsSchema>;
 export type ScriptLauncherWidgetSettings = z.infer<

--- a/packages/config/src/utils/deepMerge.ts
+++ b/packages/config/src/utils/deepMerge.ts
@@ -2,16 +2,6 @@ export function isObject(item: unknown): item is Record<string, unknown> {
   return !!(item && typeof item === 'object' && !Array.isArray(item));
 }
 
-function _dedupeById<T extends { id?: string }>(arr: T[]): T[] {
-  const seen = new Map<string, T>();
-  for (const item of arr) {
-    if (item && typeof item.id === 'string') {
-      seen.set(item.id, item);
-    }
-  }
-  return Array.from(seen.values());
-}
-
 export function deepMerge<T extends object>(target: T, source: Partial<T>): T {
   const result: T = { ...target };
 

--- a/packages/config/src/zod-types.ts
+++ b/packages/config/src/zod-types.ts
@@ -54,6 +54,7 @@ export const MainWidgetSettingsSchema = BaseWidgetSettingsSchema.extend({
   timeLocale: z.string().default('en-GB'),
   providers: ProviderSettingsSchema.default({}),
   systemStatThresholds: z.array(ThresholdSchema).default([]),
+  batteryThresholds: z.array(ThresholdSchema).default([]),
   useInlineStats: z.boolean().default(false),
 });
 

--- a/packages/config/src/zod-types.ts
+++ b/packages/config/src/zod-types.ts
@@ -39,18 +39,22 @@ export const ProviderSettingsSchema = z.object({
 });
 
 export const MainWidgetSettingsSchema = BaseWidgetSettingsSchema.extend({
-  flowLauncherPath: z.string(),
-  mediaMaxWidth: z.string(),
-  weatherThresholds: z.array(WeatherThresholdSchema),
-  weatherUnit: z.union([z.literal('celsius'), z.literal('fahrenheit')]),
-  pinnedSystrayIcons: z.array(SystrayIconSchema),
-  marginX: z.number(),
-  paddingLeft: z.number(),
-  paddingRight: z.number(),
-  dynamicWorkspaceIndicator: z.boolean(),
+  flowLauncherPath: z.string().default(''),
+  mediaMaxWidth: z.string().default('400'),
+  weatherThresholds: z.array(WeatherThresholdSchema).default([]),
+  weatherUnit: z
+    .union([z.literal('celsius'), z.literal('fahrenheit')])
+    .default('celsius'),
+  pinnedSystrayIcons: z.array(SystrayIconSchema).default([]),
+  marginX: z.number().default(0),
+  paddingLeft: z.number().default(4),
+  paddingRight: z.number().default(4),
+  dynamicWorkspaceIndicator: z.boolean().default(false),
   timeFormat: z.string().default('EEE d MMM t'),
   timeLocale: z.string().default('en-GB'),
   providers: ProviderSettingsSchema.default({}),
+  systemStatThresholds: z.array(WeatherThresholdSchema).default([]),
+  useInlineStats: z.boolean().default(false),
 });
 
 export const LauncherCommandSchema = z.object({

--- a/packages/config/src/zod-types.ts
+++ b/packages/config/src/zod-types.ts
@@ -16,7 +16,7 @@ export const LabelColorSchema = z.union([
 
 export const BaseWidgetSettingsSchema = z.object({});
 
-export const WeatherThresholdSchema = z.object({
+export const ThresholdSchema = z.object({
   id: z.string(),
   min: z.number(),
   max: z.number(),
@@ -41,7 +41,7 @@ export const ProviderSettingsSchema = z.object({
 export const MainWidgetSettingsSchema = BaseWidgetSettingsSchema.extend({
   flowLauncherPath: z.string().default(''),
   mediaMaxWidth: z.string().default('400'),
-  weatherThresholds: z.array(WeatherThresholdSchema).default([]),
+  weatherThresholds: z.array(ThresholdSchema).default([]),
   weatherUnit: z
     .union([z.literal('celsius'), z.literal('fahrenheit')])
     .default('celsius'),
@@ -53,7 +53,7 @@ export const MainWidgetSettingsSchema = BaseWidgetSettingsSchema.extend({
   timeFormat: z.string().default('EEE d MMM t'),
   timeLocale: z.string().default('en-GB'),
   providers: ProviderSettingsSchema.default({}),
-  systemStatThresholds: z.array(WeatherThresholdSchema).default([]),
+  systemStatThresholds: z.array(ThresholdSchema).default([]),
   useInlineStats: z.boolean().default(false),
 });
 

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -26,6 +26,7 @@
   },
   "dependencies": {
     "@base-ui-components/react": "1.0.0-beta.2",
+    "@overline-zebar/config": "workspace:*",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^0.460.0",

--- a/packages/ui/src/components/stat-ring/StatRing.tsx
+++ b/packages/ui/src/components/stat-ring/StatRing.tsx
@@ -1,13 +1,12 @@
 import { cn } from '../../utils/cn';
 import Ring from './components/Ring';
 import { systemStatThresholds } from './defaults/systemStatThresholds';
-import { LabelType } from './types/labelType';
-import { Thresholds } from './types/thresholds';
+import { Threshold } from '@overline-zebar/config';
 
 interface StatRingProps {
   Icon: React.ReactNode;
   stat: string;
-  threshold?: Thresholds;
+  threshold?: Threshold[];
 }
 
 export function StatRing({
@@ -24,32 +23,35 @@ export function StatRing({
     return 0;
   }
 
-  function getThresholdLabel(value: number) {
+  function getThresholdColor(value: number) {
     const range = threshold.find((r) => value >= r.min && value <= r.max);
-    return range ? range.label : LabelType.DEFAULT;
+    return range ? range.labelColor : '--text';
   }
 
   const statAsInt = getNumbersFromString(stat);
-  const thresholdLabel = getThresholdLabel(statAsInt);
+  const thresholdColor = getThresholdColor(statAsInt);
+
+  const colorClassMap: Record<string, { text: string; stroke: string }> = {
+    '--text': { text: 'text-text', stroke: 'stroke-success' },
+    '--warning': { text: 'text-warning', stroke: 'stroke-warning' },
+    '--danger': { text: 'text-danger', stroke: 'stroke-danger' },
+  };
+
+  const colors = colorClassMap[thresholdColor] || colorClassMap['--text'];
+
+  if (!colors) {
+    return null;
+  }
 
   return (
     <div
-      className={cn(
-        'flex items-center justify-center gap-1.5',
-        thresholdLabel === LabelType.DEFAULT && 'text-text',
-        thresholdLabel === LabelType.WARNING && 'text-warning',
-        thresholdLabel === LabelType.DANGER && 'text-danger'
-      )}
+      className={cn('flex items-center justify-center gap-1.5', colors.text)}
     >
       {Icon}
       <Ring
         percentage={statAsInt}
         className="h-3.5 w-3.5"
-        strokeColor={cn(
-          thresholdLabel === LabelType.DEFAULT && 'stroke-success',
-          thresholdLabel === LabelType.WARNING && 'stroke-warning',
-          thresholdLabel === LabelType.DANGER && 'stroke-danger'
-        )}
+        strokeColor={cn(colors.stroke)}
       />
     </div>
   );

--- a/packages/ui/src/components/stat-ring/defaults/systemStatThresholds.tsx
+++ b/packages/ui/src/components/stat-ring/defaults/systemStatThresholds.tsx
@@ -1,8 +1,7 @@
-import { LabelType } from '../types/labelType';
-import { Thresholds } from '../types/thresholds';
+import { Threshold } from '@overline-zebar/config';
 
-export const systemStatThresholds: Thresholds = [
-  { min: 0, max: 70, label: LabelType.DEFAULT },
-  { min: 70, max: 85, label: LabelType.WARNING },
-  { min: 85, max: 100, label: LabelType.DANGER },
+export const systemStatThresholds: Threshold[] = [
+  { id: 'stat-1', min: 0, max: 70, labelColor: '--text' },
+  { id: 'stat-2', min: 70, max: 85, labelColor: '--warning' },
+  { id: 'stat-3', min: 85, max: 100, labelColor: '--danger' },
 ];

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,7 +1,6 @@
 export { Button, buttonVariants } from './components/button';
 export { StatRing } from './components/stat-ring/StatRing';
 export { LabelType } from './components/stat-ring/types/labelType';
-export type { Thresholds } from './components/stat-ring/types/thresholds';
 export { systemStatThresholds } from './components/stat-ring/defaults/systemStatThresholds';
 export { Card, CardTitle } from './components/card/Card';
 export { Chip, chipStyles } from './components/chip';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -141,6 +141,9 @@ importers:
       '@base-ui-components/react':
         specifier: 1.0.0-beta.2
         version: 1.0.0-beta.2(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@overline-zebar/config':
+        specifier: workspace:*
+        version: link:../config
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1

--- a/widgets/README.md
+++ b/widgets/README.md
@@ -57,36 +57,62 @@ function MyComponent() {
 
 The `useWidgetSetting` hook is used for settings that are specific to a single widget. It takes the widget's name as the first argument and the setting name as the second.
 
-**Example: Creating a setting for `my-new-widget`**
+When adding a new widget with settings, you need to update **three files**:
 
-1.  **Define the setting in `zod-types.ts`**: Add a new schema for your widget's settings in `packages/config/src/zod-types.ts`.
+1. **Define the schema** in `packages/config/src/zod-types.ts`:
 
-    ```ts
-    // packages/config/src/zod-types.ts
-    export const myNewWidgetSettingsSchema = z.object({
-      mySetting: z.string().default('default-value'),
-    });
+   ```ts
+   // Add a new schema
+   export const myNewWidgetSettingsSchema = z.object({
+     mySetting: z.string().default('default-value'),
+   });
 
-    export const widgetSettingsSchema = z.object({
-      main: mainWidgetSettingsSchema,
-      'my-new-widget': myNewWidgetSettingsSchema, // Add this line
-    });
-    ```
+   // Add to AllWidgetSettingsSchema
+   export const AllWidgetSettingsSchema = z.object({
+     main: MainWidgetSettingsSchema,
+     'script-launcher': ScriptLauncherWidgetSettingsSchema,
+     'config-widget': z.object({}),
+     'my-new-widget': myNewWidgetSettingsSchema, // Add this
+   });
+   ```
 
-2.  **Use the setting in your widget**:
+2. **Add to type map** in `packages/config/src/types.ts`:
 
-    ```tsx
-    import { useWidgetSetting } from '@overline-zebar/config';
+   ```ts
+   export type WidgetSettingsMap = {
+     main: MainWidgetSettings;
+     'script-launcher': ScriptLauncherWidgetSettings;
+     'config-widget': Record<string, unknown>;
+     'my-new-widget': z.infer<typeof myNewWidgetSettingsSchema>; // Add this
+   };
+   ```
 
-    function MyWidgetComponent() {
-      const [mySetting, setMySetting] = useWidgetSetting(
-        'my-new-widget',
-        'mySetting'
-      );
+3. **Add defaults** in `packages/config/src/defaults/default-config.ts`:
 
-      // ...
-    }
-    ```
+   ```ts
+   widgets: {
+     main: { /* ... */ },
+     'script-launcher': { /* ... */ },
+     'my-new-widget': {  // Add this
+       mySetting: 'default-value',
+     },
+   },
+   ```
+
+4. **Use the setting in your widget**:
+
+   ```tsx
+   import { useWidgetSetting } from '@overline-zebar/config';
+
+   function MyWidgetComponent() {
+     const [mySetting, setMySetting] = useWidgetSetting(
+       'my-new-widget',
+       'mySetting'
+     );
+
+     // ...
+   }
+   ```
 
 ### `@overline-zebar/ui`
 

--- a/widgets/config-widget/src/components/pages/AppearanceSettings.tsx
+++ b/widgets/config-widget/src/components/pages/AppearanceSettings.tsx
@@ -38,7 +38,7 @@ function AppearanceSettings() {
             <FieldTitle>Border Radius</FieldTitle>
             <FieldInput>
               <Select
-                onValueChange={setRadius}
+                onValueChange={(value) => setRadius(value as string)}
                 defaultValue={radius}
                 items={selectOptions}
               >

--- a/widgets/config-widget/src/components/pages/widgets/main/components/SystemStatsTab.tsx
+++ b/widgets/config-widget/src/components/pages/widgets/main/components/SystemStatsTab.tsx
@@ -5,7 +5,7 @@ import {
   FormField,
   Switch,
 } from '@overline-zebar/ui';
-import WeatherThresholds from './WeatherThresholds';
+import ThresholdsInput from './ThresholdsInput';
 import { useWidgetSetting, ProviderSettings } from '@overline-zebar/config';
 import { Separator } from '@/components/common/Separator';
 
@@ -26,6 +26,10 @@ export default function SystemStatsTab() {
   const [systemStatThresholds, setSystemStatThresholds] = useWidgetSetting(
     'main',
     'systemStatThresholds'
+  );
+  const [batteryThresholds, setBatteryThresholds] = useWidgetSetting(
+    'main',
+    'batteryThresholds'
   );
 
   const handleProviderToggle = (
@@ -95,7 +99,7 @@ export default function SystemStatsTab() {
                   Configure color ranges based on usage percentage.
                 </p>
               </div>
-              <WeatherThresholds
+              <ThresholdsInput
                 thresholds={systemStatThresholds}
                 onChange={setSystemStatThresholds}
               />
@@ -133,9 +137,29 @@ export default function SystemStatsTab() {
                 each range.
               </p>
             </div>
-            <WeatherThresholds />
+            <ThresholdsInput />
           </div>
         </div>
+      )}
+
+      {/* Battery Thresholds */}
+      {providers.battery && (
+        <>
+          <Separator />
+          <div className="space-y-4">
+            <div className="space-y-0.5">
+              <h1 className="text-text">Battery Thresholds</h1>
+              <p className="text-text-muted">
+                Configure color ranges based on battery percentage.
+              </p>
+            </div>
+            <ThresholdsInput
+              thresholds={batteryThresholds}
+              onChange={setBatteryThresholds}
+              settingKey="batteryThresholds"
+            />
+          </div>
+        </>
       )}
     </>
   );

--- a/widgets/config-widget/src/components/pages/widgets/main/components/SystemStatsTab.tsx
+++ b/widgets/config-widget/src/components/pages/widgets/main/components/SystemStatsTab.tsx
@@ -19,6 +19,14 @@ const providerLabels: Record<keyof ProviderSettings, string> = {
 export default function SystemStatsTab() {
   const [providers, setProviders] = useWidgetSetting('main', 'providers');
   const [weatherUnit, setWeatherUnit] = useWidgetSetting('main', 'weatherUnit');
+  const [useInlineStats, setUseInlineStats] = useWidgetSetting(
+    'main',
+    'useInlineStats'
+  );
+  const [systemStatThresholds, setSystemStatThresholds] = useWidgetSetting(
+    'main',
+    'systemStatThresholds'
+  );
 
   const handleProviderToggle = (
     provider: keyof ProviderSettings,
@@ -55,6 +63,46 @@ export default function SystemStatsTab() {
           )}
         </div>
       </div>
+
+      {/* CPU & RAM Display Settings */}
+      {(providers.cpu || providers.memory) && (
+        <>
+          <Separator />
+          <div className="space-y-4">
+            <div className="space-y-0.5 mb-4">
+              <h1 className="text-text">CPU & RAM Display</h1>
+              <p className="text-text-muted">
+                Configure how system statistics are displayed.
+              </p>
+            </div>
+            <FormField switch>
+              <FieldTitle>Use Inline Stats</FieldTitle>
+              <FieldInput>
+                <Switch
+                  checked={useInlineStats}
+                  onCheckedChange={setUseInlineStats}
+                />
+              </FieldInput>
+              <FieldDescription>
+                Display CPU and RAM usage as inline text instead of ring
+                visualization.
+              </FieldDescription>
+            </FormField>
+            <div className="space-y-4">
+              <div className="space-y-0.5">
+                <h1 className="text-text">Thresholds</h1>
+                <p className="text-text-muted">
+                  Configure color ranges based on usage percentage.
+                </p>
+              </div>
+              <WeatherThresholds
+                thresholds={systemStatThresholds}
+                onChange={setSystemStatThresholds}
+              />
+            </div>
+          </div>
+        </>
+      )}
 
       {/* Divider */}
       <Separator />

--- a/widgets/config-widget/src/components/pages/widgets/main/components/ThresholdsInput.tsx
+++ b/widgets/config-widget/src/components/pages/widgets/main/components/ThresholdsInput.tsx
@@ -14,17 +14,20 @@ import {
 } from '@overline-zebar/ui';
 import { NumberInput } from '../../../../NumberInput';
 
-interface WeatherThresholdsProps {
+interface ThresholdsInputProps {
   thresholds?: Threshold[];
   onChange?: (thresholds: Threshold[]) => void;
-  settingKey?: 'weatherThresholds' | 'systemStatThresholds';
+  settingKey?:
+    | 'weatherThresholds'
+    | 'systemStatThresholds'
+    | 'batteryThresholds';
 }
 
-export function WeatherThresholds({
+export function ThresholdsInput({
   thresholds: thresholdsProp,
   onChange: onChangeProp,
   settingKey = 'weatherThresholds',
-}: WeatherThresholdsProps = {}) {
+}: ThresholdsInputProps = {}) {
   const [thresholdsInternal, setThresholdsInternal] = useWidgetSetting(
     'main',
     settingKey
@@ -125,4 +128,4 @@ function ThresholdColorSelect({
   );
 }
 
-export default WeatherThresholds;
+export default ThresholdsInput;

--- a/widgets/config-widget/src/components/pages/widgets/main/components/TimeTab.tsx
+++ b/widgets/config-widget/src/components/pages/widgets/main/components/TimeTab.tsx
@@ -46,9 +46,12 @@ function TimeTab() {
       <FormField>
         <FieldTitle>Time Format</FieldTitle>
         <FieldInput>
-          <Select value={timeFormat} onValueChange={setTimeFormat}>
+          <Select
+            value={timeFormat}
+            onValueChange={(value) => setTimeFormat(value as string)}
+          >
             <SelectTrigger>
-              <SelectValue placeholder="Select a time format" />
+              <SelectValue />
             </SelectTrigger>
             <SelectContent>
               {TIME_FORMATS.map((format) => (
@@ -67,9 +70,12 @@ function TimeTab() {
       <FormField>
         <FieldTitle>Time Locale</FieldTitle>
         <FieldInput>
-          <Select value={timeLocale} onValueChange={setTimeLocale}>
+          <Select
+            value={timeLocale}
+            onValueChange={(value) => setTimeLocale(value as string)}
+          >
             <SelectTrigger>
-              <SelectValue placeholder="Select a locale" />
+              <SelectValue />
             </SelectTrigger>
             <SelectContent>
               {TIME_LOCALES.map((locale) => (

--- a/widgets/config-widget/src/components/pages/widgets/main/components/WeatherThresholds.tsx
+++ b/widgets/config-widget/src/components/pages/widgets/main/components/WeatherThresholds.tsx
@@ -1,7 +1,7 @@
 import {
   LabelColor,
   useWidgetSetting,
-  WeatherThreshold,
+  Threshold,
 } from '@overline-zebar/config';
 import {
   FieldTitle,
@@ -14,16 +14,46 @@ import {
 } from '@overline-zebar/ui';
 import { NumberInput } from '../../../../NumberInput';
 
-export function WeatherThresholds() {
-  const [thresholds] = useWidgetSetting('main', 'weatherThresholds');
+interface WeatherThresholdsProps {
+  thresholds?: Threshold[];
+  onChange?: (thresholds: Threshold[]) => void;
+  settingKey?: 'weatherThresholds' | 'systemStatThresholds';
+}
+
+export function WeatherThresholds({
+  thresholds: thresholdsProp,
+  onChange: onChangeProp,
+  settingKey = 'weatherThresholds',
+}: WeatherThresholdsProps = {}) {
+  const [thresholdsInternal, setThresholdsInternal] = useWidgetSetting(
+    'main',
+    settingKey
+  );
+
+  const thresholds = thresholdsProp ?? thresholdsInternal;
+  const setThresholds = onChangeProp ?? setThresholdsInternal;
 
   return (
     <div className="w-full space-y-3">
-      {(thresholds ?? []).map((t) => (
-        <div className="flex items-center gap-4 w-full">
-          <ThresholdInput threshold={t} minOrMax="min" />
-          <ThresholdInput threshold={t} minOrMax="max" />
-          <ThresholdColorSelect threshold={t} />
+      {(thresholds ?? []).map((t: Threshold) => (
+        <div className="flex items-center gap-4 w-full" key={t.id}>
+          <ThresholdInput
+            threshold={t}
+            minOrMax="min"
+            thresholds={thresholds}
+            setThresholds={setThresholds}
+          />
+          <ThresholdInput
+            threshold={t}
+            minOrMax="max"
+            thresholds={thresholds}
+            setThresholds={setThresholds}
+          />
+          <ThresholdColorSelect
+            threshold={t}
+            thresholds={thresholds}
+            setThresholds={setThresholds}
+          />
         </div>
       ))}
     </div>
@@ -31,16 +61,18 @@ export function WeatherThresholds() {
 }
 
 type ThresholdInputProps = {
-  threshold: WeatherThreshold;
+  threshold: Threshold;
   minOrMax: 'min' | 'max';
+  thresholds: Threshold[];
+  setThresholds: (thresholds: Threshold[]) => void;
 };
 
-function ThresholdInput({ threshold, minOrMax }: ThresholdInputProps) {
-  const [thresholds, setThresholds] = useWidgetSetting(
-    'main',
-    'weatherThresholds'
-  );
-
+function ThresholdInput({
+  threshold,
+  minOrMax,
+  thresholds,
+  setThresholds,
+}: ThresholdInputProps) {
   const handleChange = (newValue: number) => {
     const newThresholds = thresholds.map((t) =>
       t.id === threshold.id ? { ...t, [minOrMax]: newValue } : t
@@ -59,15 +91,16 @@ function ThresholdInput({ threshold, minOrMax }: ThresholdInputProps) {
 }
 
 type ThresholdColorSelectProps = {
-  threshold: WeatherThreshold;
+  threshold: Threshold;
+  thresholds: Threshold[];
+  setThresholds: (thresholds: Threshold[]) => void;
 };
 
-function ThresholdColorSelect({ threshold }: ThresholdColorSelectProps) {
-  const [thresholds, setThresholds] = useWidgetSetting(
-    'main',
-    'weatherThresholds'
-  );
-
+function ThresholdColorSelect({
+  threshold,
+  thresholds,
+  setThresholds,
+}: ThresholdColorSelectProps) {
   const handleColorChange = (newValue: unknown) => {
     const newThresholds = thresholds.map((t) =>
       t.id === threshold.id ? { ...t, labelColor: newValue as LabelColor } : t

--- a/widgets/main/src/App.tsx
+++ b/widgets/main/src/App.tsx
@@ -36,7 +36,7 @@ function App() {
 
   useAutoTiling();
 
-  const statIconClassnames = 'h-3.5 w-3.5 text-icon';
+  const volumeIconClassnames = 'h-3.5 w-3.5 text-icon';
   const [marginX] = useWidgetSetting('main', 'marginX');
   const [paddingLeft] = useWidgetSetting('main', 'paddingLeft');
   const [paddingRight] = useWidgetSetting('main', 'paddingRight');
@@ -84,7 +84,7 @@ function App() {
         <div className="flex items-center h-full">
           <VolumeControl
             audio={output.audio}
-            statIconClassnames={statIconClassnames}
+            iconClassnames={volumeIconClassnames}
           />
         </div>
         <div className="h-full flex items-center px-0.5">

--- a/widgets/main/src/components/stat/Stat.tsx
+++ b/widgets/main/src/components/stat/Stat.tsx
@@ -1,5 +1,5 @@
-import { WeatherThreshold } from '@overline-zebar/config';
-import { StatRing, Thresholds } from '@overline-zebar/ui';
+import { Threshold } from '@overline-zebar/config';
+import { StatRing } from '@overline-zebar/ui';
 import { StatInline } from './components/StatInline';
 
 interface BaseStatProps {
@@ -7,11 +7,10 @@ interface BaseStatProps {
   stat: string;
 }
 
-type StatProps = BaseStatProps &
-  (
-    | { type: 'ring'; threshold?: Thresholds }
-    | { type: 'inline'; threshold?: WeatherThreshold[] }
-  );
+type StatProps = BaseStatProps & {
+  type: 'ring' | 'inline';
+  threshold?: Threshold[];
+};
 
 export default function Stat(props: StatProps) {
   switch (props.type) {

--- a/widgets/main/src/components/stat/components/StatInline.tsx
+++ b/widgets/main/src/components/stat/components/StatInline.tsx
@@ -1,10 +1,10 @@
-import { WeatherThreshold } from '@overline-zebar/config';
+import { Threshold } from '@overline-zebar/config';
 import { cn } from '../../../utils/cn';
 
 interface StatProps {
   Icon: React.ReactNode;
   stat: string;
-  threshold?: WeatherThreshold[];
+  threshold?: Threshold[];
 }
 
 export function StatInline({ Icon, stat, threshold }: StatProps) {
@@ -28,7 +28,7 @@ export function StatInline({ Icon, stat, threshold }: StatProps) {
       style={{ color: thresholdLabel ? `var(${thresholdLabel})` : undefined }}
     >
       {Icon}
-      <p>{stat}</p>
+      <p className="tabular-nums">{stat}</p>
     </div>
   );
 }

--- a/widgets/main/src/components/stat/defaults/thresholds.tsx
+++ b/widgets/main/src/components/stat/defaults/thresholds.tsx
@@ -1,8 +1,0 @@
-import { LabelType, Thresholds } from '@overline-zebar/ui';
-
-export const weatherThresholds: Thresholds = [
-  { min: -10, max: 0, label: LabelType.DANGER },
-  { min: 1, max: 15, label: LabelType.DEFAULT },
-  { min: 16, max: 25, label: LabelType.WARNING },
-  { min: 26, max: 35, label: LabelType.DANGER },
-];

--- a/widgets/main/src/components/statProviders/index.tsx
+++ b/widgets/main/src/components/statProviders/index.tsx
@@ -39,7 +39,7 @@ export default function StatProviders({
     'systemStatThresholds'
   );
   const chipRef = useRef<HTMLDivElement | null>(null);
-  const statIconClassnames = 'size-3.5 -mt-0.5 text-icon';
+  const statIconClassnames = 'size-3.5 text-icon';
 
   if (allProvidersDisabled) return null;
 

--- a/widgets/main/src/components/statProviders/index.tsx
+++ b/widgets/main/src/components/statProviders/index.tsx
@@ -5,6 +5,24 @@ import { Chip } from '@overline-zebar/ui';
 import { calculateWidgetPlacementFromRight } from '../../utils/calculateWidgetPlacement';
 import { getWeatherIcon } from '../../utils/weatherIcons';
 
+// ============================================================================
+// BATTERY TESTING - Toggle this variable to test different battery levels
+// ============================================================================
+const TEST_BATTERY: zebar.BatteryOutput | null = {
+  chargePercent: 65, // Change to test: 15 (danger), 25 (warning), 55 (text)
+  isCharging: true, // Toggle true/false to test charging states
+  healthPercent: 92,
+  cycleCount: 250,
+  powerConsumption: 12.5,
+  voltage: 11.4,
+  timeTillFull: null,
+  timeTillEmpty: 7200000,
+  state: 'discharging',
+};
+// Set to null to use real battery, or uncomment above to test
+const USE_TEST_BATTERY = false; // Toggle to true to enable testing
+// ============================================================================
+
 import Stat from '../stat/Stat';
 
 import {
@@ -89,7 +107,7 @@ export default function StatProviders({
       )}
 
       <BatteryStat
-        battery={battery}
+        battery={USE_TEST_BATTERY ? TEST_BATTERY : battery}
         batteryProvider={statProviders.battery}
         batteryThresholds={batteryThresholds}
       />
@@ -115,14 +133,12 @@ function BatteryStat({
   const renderBatteryIcon = () => {
     if (battery.isCharging) {
       return (
-        <BatteryCharging strokeWidth={3} className="h-3.5 w-3.5 text-success" />
+        <BatteryCharging strokeWidth={3} className="h-3.5 w-3.5 text-icon" />
       );
     }
 
     if (chargePercent >= 80) {
-      return (
-        <BatteryFull strokeWidth={3} className="h-3.5 w-3.5 text-success" />
-      );
+      return <BatteryFull strokeWidth={3} className="h-3.5 w-3.5 text-icon" />;
     }
 
     if (chargePercent >= 40) {
@@ -131,9 +147,7 @@ function BatteryStat({
       );
     }
 
-    return (
-      <BatteryLow strokeWidth={3} className="h-3.5 w-3.5 text-destructive" />
-    );
+    return <BatteryLow strokeWidth={3} className="h-3.5 w-3.5 text-icon" />;
   };
 
   return (

--- a/widgets/main/src/components/statProviders/index.tsx
+++ b/widgets/main/src/components/statProviders/index.tsx
@@ -1,6 +1,6 @@
 import { useRef } from 'react';
 import * as zebar from 'zebar';
-import { useWidgetSetting } from '@overline-zebar/config';
+import { useWidgetSetting, Threshold } from '@overline-zebar/config';
 import { Chip } from '@overline-zebar/ui';
 import { calculateWidgetPlacementFromRight } from '../../utils/calculateWidgetPlacement';
 import { getWeatherIcon } from '../../utils/weatherIcons';
@@ -38,6 +38,7 @@ export default function StatProviders({
     'main',
     'systemStatThresholds'
   );
+  const [batteryThresholds] = useWidgetSetting('main', 'batteryThresholds');
   const chipRef = useRef<HTMLDivElement | null>(null);
   const statIconClassnames = 'size-3.5 text-icon';
 
@@ -87,7 +88,11 @@ export default function StatProviders({
         />
       )}
 
-      <BatteryStat battery={battery} batteryProvider={statProviders.battery} />
+      <BatteryStat
+        battery={battery}
+        batteryProvider={statProviders.battery}
+        batteryThresholds={batteryThresholds}
+      />
     </Chip>
   );
 }
@@ -95,9 +100,14 @@ export default function StatProviders({
 type BatteryStatProps = {
   battery: zebar.BatteryOutput | null;
   batteryProvider: boolean;
+  batteryThresholds: Threshold[];
 };
 
-function BatteryStat({ battery, batteryProvider }: BatteryStatProps) {
+function BatteryStat({
+  battery,
+  batteryProvider,
+  batteryThresholds,
+}: BatteryStatProps) {
   if (!batteryProvider || !battery) return null;
 
   const chargePercent = Math.round(battery.chargePercent);
@@ -127,6 +137,11 @@ function BatteryStat({ battery, batteryProvider }: BatteryStatProps) {
   };
 
   return (
-    <Stat Icon={renderBatteryIcon()} stat={`${chargePercent}%`} type="inline" />
+    <Stat
+      Icon={renderBatteryIcon()}
+      stat={`${chargePercent}%`}
+      type="inline"
+      threshold={batteryThresholds}
+    />
   );
 }

--- a/widgets/main/src/components/statProviders/index.tsx
+++ b/widgets/main/src/components/statProviders/index.tsx
@@ -33,8 +33,13 @@ export default function StatProviders({
   );
   const [weatherThresholds] = useWidgetSetting('main', 'weatherThresholds');
   const [weatherUnit] = useWidgetSetting('main', 'weatherUnit');
+  const [useInlineStats] = useWidgetSetting('main', 'useInlineStats');
+  const [systemStatThresholds] = useWidgetSetting(
+    'main',
+    'systemStatThresholds'
+  );
   const chipRef = useRef<HTMLDivElement | null>(null);
-  const statIconClassnames = 'h-3.5 w-3.5 text-icon';
+  const statIconClassnames = 'size-3.5 -mt-0.5 text-icon';
 
   if (allProvidersDisabled) return null;
 
@@ -55,7 +60,8 @@ export default function StatProviders({
         <Stat
           Icon={<p className="font-medium text-icon">CPU</p>}
           stat={`${Math.round(cpu.usage)}%`}
-          type="ring"
+          type={useInlineStats ? 'inline' : 'ring'}
+          threshold={systemStatThresholds}
         />
       )}
 
@@ -63,7 +69,8 @@ export default function StatProviders({
         <Stat
           Icon={<p className="font-medium text-icon">RAM</p>}
           stat={`${Math.round(memory.usage)}%`}
-          type="ring"
+          type={useInlineStats ? 'inline' : 'ring'}
+          threshold={systemStatThresholds}
         />
       )}
 

--- a/widgets/main/src/components/volume/VolumeControl.tsx
+++ b/widgets/main/src/components/volume/VolumeControl.tsx
@@ -6,10 +6,10 @@ import { AudioOutput } from 'zebar';
 import Slider from './components/Slider';
 
 export default function VolumeControl({
-  statIconClassnames,
+  iconClassnames,
   audio,
 }: {
-  statIconClassnames: string;
+  iconClassnames: string;
   audio: AudioOutput | null;
 }) {
   const [expanded, setExpanded] = useState(false);
@@ -66,11 +66,11 @@ export default function VolumeControl({
 
   const renderIcon = () => {
     if (playbackDevice.volume === 0) {
-      return <Volume className={statIconClassnames} strokeWidth={3} />;
+      return <Volume className={iconClassnames} strokeWidth={3} />;
     } else if (playbackDevice.volume > 0 && playbackDevice.volume < 60) {
-      return <Volume1 className={statIconClassnames} strokeWidth={3} />;
+      return <Volume1 className={iconClassnames} strokeWidth={3} />;
     } else {
-      return <Volume2 className={statIconClassnames} strokeWidth={3} />;
+      return <Volume2 className={iconClassnames} strokeWidth={3} />;
     }
   };
 

--- a/widgets/main/src/components/volume/components/Slider.tsx
+++ b/widgets/main/src/components/volume/components/Slider.tsx
@@ -41,7 +41,7 @@ export default function Slider({
       <RadixSlider.Root
         ref={ref}
         value={[value]}
-        onValueChange={([v]) => setValue(Math.floor(v))}
+        onValueChange={([v]) => v !== undefined && setValue(Math.floor(v))}
         onClick={(e) => e.stopPropagation()}
         step={0.01}
         className="relative flex w-full cursor-grab touch-none select-none rounded-full items-center active:cursor-grabbing"

--- a/widgets/main/src/utils/weatherIcons.tsx
+++ b/widgets/main/src/utils/weatherIcons.tsx
@@ -17,28 +17,28 @@ export const getWeatherIcon = (
 ) => {
   switch (weatherOutput.status) {
     case 'clear_day':
-      return <Sun strokeWidth={3} className={iconClass} />;
+      return <Sun strokeWidth={2.5} className={iconClass} />;
     case 'clear_night':
-      return <Moon strokeWidth={3} className={iconClass} />;
+      return <Moon strokeWidth={2.5} className={iconClass} />;
     case 'cloudy_day':
-      return <CloudSun strokeWidth={3} className={iconClass} />;
+      return <CloudSun strokeWidth={2.5} className={iconClass} />;
     case 'cloudy_night':
-      return <CloudMoon strokeWidth={3} className={iconClass} />;
+      return <CloudMoon strokeWidth={2.5} className={iconClass} />;
     case 'light_rain_day':
     case 'light_rain_night':
     case 'thunder_night':
-      return <CloudDrizzle strokeWidth={3} className={iconClass} />;
+      return <CloudDrizzle strokeWidth={2.5} className={iconClass} />;
     case 'heavy_rain_day':
-      return <CloudRain strokeWidth={3} className={iconClass} />;
+      return <CloudRain strokeWidth={2.5} className={iconClass} />;
     case 'heavy_rain_night':
-      return <CloudRain strokeWidth={3} className={iconClass} />;
+      return <CloudRain strokeWidth={2.5} className={iconClass} />;
     case 'snow_day':
-      return <CloudSnow strokeWidth={3} className={iconClass} />;
+      return <CloudSnow strokeWidth={2.5} className={iconClass} />;
     case 'snow_night':
-      return <CloudSnow strokeWidth={3} className={iconClass} />;
+      return <CloudSnow strokeWidth={2.5} className={iconClass} />;
     case 'thunder_day':
-      return <CloudLightning strokeWidth={3} className={iconClass} />;
+      return <CloudLightning strokeWidth={2.5} className={iconClass} />;
     default:
-      return <Cloud strokeWidth={3} className={iconClass} />;
+      return <Cloud strokeWidth={2.5} className={iconClass} />;
   }
 };

--- a/widgets/system-stats/src/components/host/components/BatterySection.tsx
+++ b/widgets/system-stats/src/components/host/components/BatterySection.tsx
@@ -1,12 +1,16 @@
 import { Battery, Cable, Heart, PlugZap, RefreshCcw, Zap } from 'lucide-react';
 import { BatteryOutput } from 'zebar';
 import { formatMsToHumanDuration } from '@/utils/time';
-import { cn } from '@/utils/cn';
+import { Threshold, useWidgetSetting } from '@overline-zebar/config';
 
 type BatteryProps = {
   battery: BatteryOutput;
+  thresholds?: Threshold[];
 };
-export function BatterySection({ battery }: BatteryProps) {
+export function BatterySection({ battery, thresholds }: BatteryProps) {
+  const [configThresholds] = useWidgetSetting('main', 'batteryThresholds');
+  const batteryThresholds = thresholds ?? configThresholds;
+
   const timeTillFullOrEmpty = battery.isCharging
     ? battery.timeTillFull
     : battery.timeTillEmpty;
@@ -14,16 +18,14 @@ export function BatterySection({ battery }: BatteryProps) {
   const formatTimeTillFullOrEmpty = timeTillFullOrEmpty
     ? `${formatMsToHumanDuration(timeTillFullOrEmpty)} ${status}`
     : null;
-  const batteryThreshold = () => {
-    const batteryPercentage = battery.chargePercent;
-    if (batteryPercentage >= 0 && batteryPercentage <= 20) {
-      return 'danger';
-    } else if (batteryPercentage >= 20 && batteryPercentage <= 60) {
-      return 'warning';
-    } else {
-      return 'success';
-    }
-  };
+
+  function getThresholdLabel(value: number) {
+    if (!batteryThresholds) return '--text';
+    const range = batteryThresholds.find(
+      (r) => value >= r.min && value <= r.max
+    );
+    return range ? range.labelColor : '--text';
+  }
 
   return (
     <div className="space-y-3">
@@ -38,7 +40,14 @@ export function BatterySection({ battery }: BatteryProps) {
             ) : (
               <Battery className="h-4 w-4 text-icon" />
             )}
-            <p className="text-text">{battery.chargePercent}%</p>
+            <p
+              className="text-text"
+              style={{
+                color: `var(${getThresholdLabel(battery.chargePercent)})`,
+              }}
+            >
+              {battery.chargePercent}%
+            </p>
           </div>
           {formatTimeTillFullOrEmpty && (
             <p>{`~ ${formatTimeTillFullOrEmpty}`}</p>
@@ -47,13 +56,11 @@ export function BatterySection({ battery }: BatteryProps) {
         <div className="h-2 w-full bg-background border-border border overflow-clip rounded">
           <div
             title={`${battery.chargePercent}%`}
-            className={cn(
-              'h-full',
-              batteryThreshold() === 'danger' && 'bg-danger',
-              batteryThreshold() === 'warning' && 'bg-warning',
-              batteryThreshold() === 'success' && 'bg-success'
-            )}
-            style={{ width: battery.chargePercent + '%' }}
+            className="h-full"
+            style={{
+              width: battery.chargePercent + '%',
+              backgroundColor: `var(${getThresholdLabel(battery.chargePercent)})`,
+            }}
           />
         </div>
       </div>

--- a/zpack.json
+++ b/zpack.json
@@ -43,9 +43,9 @@
           "name": "default",
           "anchor": "top_center",
           "offsetX": "0px",
-          "offsetY": "2px",
+          "offsetY": "0px",
           "width": "100%",
-          "height": "36px",
+          "height": "35px",
           "monitorSelection": {
             "type": "all"
           },

--- a/zpack.json
+++ b/zpack.json
@@ -45,7 +45,7 @@
           "offsetX": "0px",
           "offsetY": "0px",
           "width": "100%",
-          "height": "35px",
+          "height": "34px",
           "monitorSelection": {
             "type": "all"
           },


### PR DESCRIPTION
## Summary

This PR introduces configurable battery thresholds, aligning them with the existing system stats and weather threshold systems. It also refactors the threshold abstraction to be more general-purpose and improves naming consistency across the codebase.

---

## Changes

### Core Features

#### 1. Battery Threshold System
- Added `batteryThresholds` setting to `MainWidgetSettingsSchema`
- Default thresholds:
  - `0–20%` → danger (red)
  - `20–60%` → warning (yellow)
  - `60–100%` → text (white)
- Battery percentage text now updates colour based on configurable thresholds
- Applied to both the main widget and system-stats widget

#### 2. Threshold System Refactor
- Renamed `WeatherThresholdSchema` → `ThresholdSchema` (generalised usage)
- Removed `WeatherThreshold` type alias in favour of `Threshold`
- Renamed `WeatherThresholds` component → `ThresholdsInput`
- Updated type imports across the codebase

---

### Configuration UI

#### 3. Battery Threshold Configuration
- Added **Battery Thresholds** section in:
  - Config Widget → System Stats tab
- Reuses existing `ThresholdsInput` component
- Visible when battery provider is enabled
- Supports customisation of:
  - Min/max ranges
  - Colours

---

### Widget Updates

#### 4. Main Widget (`widgets/main`)
- `BatteryStat` component now accepts a `threshold` prop
- Battery percentage text reflects threshold colours
- Battery icons:
  - Always use `text-icon` (grey)
  - No longer change colour
- Icon shapes still reflect battery level:
  - Low: `< 40%`
  - Medium: `40–80%`
  - Full: `≥ 80%`
  - Charging state supported
- Added mock battery testing via `USE_TEST_BATTERY` in `statProviders/index.tsx`

#### 5. System-Stats Widget (`widgets/system-stats`)
- `BatterySection` now uses configurable thresholds
- Removed hardcoded `batteryThreshold()` function
- Applied threshold colours to:
  - Percentage text
  - Progress bar
- Preserved charging icon animation

---

### Testing

#### 6. Mock Battery Support
- Added test mode in:
  - `widgets/main/src/components/statProviders/index.tsx`
- Usage:
  - Toggle `USE_TEST_BATTERY`
  - Set `TEST_BATTERY` values
- Enables testing of:
  - Different battery levels
  - Charging states
- Useful for desktop environments without battery hardware