### PR TITLE
feat: show paused indicator when the WM is paused

### DIFF
--- a/widgets/main/src/components/leftButtons/index.tsx
+++ b/widgets/main/src/components/leftButtons/index.tsx
@@ -37,6 +37,21 @@ export function LeftButtons({ glazewm }: LeftButtonsProps) {
   return (
     <div className="flex items-center h-full gap-1.5">
       <AnimatePresence>
+        {glazewm.isPaused && (
+          <motion.div
+            key="paused"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            transition={{ duration: 0.15, ease: 'easeInOut' }}
+            exit={{ opacity: 0 }}
+            className="flex items-center h-full"
+          >
+            <Button size="sm" onClick={() => glazewm.runCommand('wm-toggle-pause')}>
+              paused
+            </Button>
+          </motion.div>
+        )}
+
         {glazewm.bindingModes.map((bindingMode) => (
           <motion.div
             key={bindingMode.name}


### PR DESCRIPTION
## What

Adds a `paused` indicator to the left side of the bar, shown when GlazeWM is paused (`wm-toggle-pause`). Clicking it runs `wm-toggle-pause` to unpause.

## Why

The bar already surfaces binding modes (e.g. `resize`) via `glazewm.bindingModes`, but the paused state is **not** a binding mode — it's a separate `GlazeWmOutput.isPaused` flag. So when the WM is paused there was no visual feedback in the bar.

## How

- Render a button from `glazewm.isPaused`, placed alongside the existing binding-mode buttons inside the same `AnimatePresence` (same fade in/out animation for consistency).
- Label is lowercase `paused` to match how binding modes render (`resize` is lowercase via `displayName ?? name`).
- Click handler calls `glazewm.runCommand('wm-toggle-pause')`.

## Notes

- `isPaused` requires GlazeWM >= 3.7.0 (older versions report `false`), and is already part of the bundled `zebar` types (3.3.1).
- No new dependencies.

## Screenshots

<img width="157" height="39" alt="Screenshot 2026-06-28 192135" src="https://github.com/user-attachments/assets/25ad76f4-65cc-4b75-a776-65c9fef1f256" />
